### PR TITLE
Chore/add karma js to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
 cache:
   directories:
     - node_modules
+    - generatorTests/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ install:
     - npm install -g gulp
 script: 
     - mocha
+cache:
+  directories:
+    - node_modules

--- a/_config/project.json
+++ b/_config/project.json
@@ -11,7 +11,11 @@
         "reports": 		"reports"
     },
     "tests" : {
-        "configFile" : "karma.conf.js"
+        "configFile" : "karma.conf.js",
+        "reporters" : {
+            "production": ["teamcity"],
+            "dev": ["mocha"]
+        }
     },
     "pixelBase": "16px",
     "pixelBaseNoUnit": 16

--- a/_config/project.json
+++ b/_config/project.json
@@ -10,6 +10,9 @@
         "fonts": 	"fonts",
         "reports": 		"reports"
     },
+    "tests" : {
+        "configFile" : "karma.conf.js"
+    },
     "pixelBase": "16px",
     "pixelBaseNoUnit": 16
 }

--- a/generatorTests/test/gulpSpec.js
+++ b/generatorTests/test/gulpSpec.js
@@ -30,7 +30,7 @@ function cleanBuildAndReleaseFolders() {
 
 describe('As a dev', function() {
 
-    this.timeout(20000);
+    this.timeout(100000);
 
     before(function(done) {
         cleanBuildAndReleaseFolders();

--- a/generatorTests/test/gulpSpec.js
+++ b/generatorTests/test/gulpSpec.js
@@ -30,7 +30,7 @@ function cleanBuildAndReleaseFolders() {
 
 describe('As a dev', function() {
 
-    this.timeout(10000);
+    this.timeout(20000);
 
     before(function(done) {
         cleanBuildAndReleaseFolders();

--- a/gulpTasks/unit-testing.js
+++ b/gulpTasks/unit-testing.js
@@ -1,0 +1,17 @@
+/* ============================================================ *\
+    UNIT TESTING
+\* ============================================================ */
+
+var path = require('path');
+
+var karmaServer = require('karma').Server
+
+module.exports = function(gulp, config) {
+
+    gulp.task('tests', function(done) {
+        new karmaServer({
+            configFile: path.resolve(__dirname, '..', config.tests.configFile)
+        }, done).start();
+    });
+
+}

--- a/gulpTasks/unit-testing.js
+++ b/gulpTasks/unit-testing.js
@@ -6,11 +6,15 @@ var path = require('path');
 
 var karmaServer = require('karma').Server
 
-module.exports = function(gulp, config) {
+module.exports = function(gulp, config, argv) {
 
     gulp.task('tests', function(done) {
+        var karmaReportsFromConfig = config.tests.reporters;
+        var karmaReportersToUse = (argv.prod) ? karmaReportsFromConfig.production : karmaReportsFromConfig.dev;
+
         new karmaServer({
-            configFile: path.resolve(__dirname, '..', config.tests.configFile)
+            configFile: path.resolve(__dirname, '..', config.tests.configFile),
+            reporters: karmaReportersToUse
         }, done).start();
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ require('./gulpTasks/copy-assets.js')(gulp, config);
 require('./gulpTasks/release.js')(gulp, creds);
 require('./gulpTasks/compile-html.js')(gulp);
 require('./gulpTasks/local-testing.js')(gulp, config);
+require('./gulpTasks/unit-testing.js')(gulp, config, argv);
 require('./gulpTasks/new-component.js')(gulp, argv);
 
 /* ============================================================ *\

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('watch:js', function () {
 	if(!argv.prod) {
 		gulp.watch(
 			[config.paths.src.scripts + '/**/*.js', config.paths.src.components + '/**/*.js'],
-			['scripts']
+			['tests', 'scripts']
 		);
 	}
 });
@@ -87,5 +87,5 @@ gulp.task('dev', function(cb) {
 });
 
 gulp.task('default', function (cb) {
-	runSeq(['clean'],['sass-generate-contents'],['sass', 'scripts','scripts:vendor' ,'scripts:ie' ,'copy:fonts', 'imagemin'], ['sass:legacy:ie8'], cb);
+	runSeq(['clean'],['sass-generate-contents'],['sass', 'scripts','scripts:vendor' ,'scripts:ie' ,'copy:fonts', 'imagemin'], ['sass:legacy:ie8'], ['tests'], cb);
 });

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "git+https://github.com/code-computerlove/node-static-site-generator"
   },
   "scripts": {
-  	"start": "gulp watch && gulp serve",
-    "test": "./node_modules/karma/bin/karma start karma.conf.js"
+    "start": "gulp watch && gulp serve"
   },
   "license": "ISC",
   "dependencies": {
@@ -59,6 +58,7 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "^0.2.0",
+    "karma-teamcity-reporter": "^0.2.1",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.17"
   }


### PR DESCRIPTION
Running tests using `npm test` works but is not cross-platform (Windows wouldn't be able to recognise the aliased command).

I've moved this into the gulp build, which allows the tests to be easily added to watch, release tasks etc.

Depending on the if the `--prod` flag is provided, when the tests are run it will either pretty print it in the console or format it for teamcity.

The tests are now run in the following tasks

* watch:js
* default (release & build)