### PR TITLE
chore: Update gulp-compile-handlebars-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-method-override": "0.0.3",
     "express-session": "^1.10.2",
     "gulp": "^3.8.11",
-    "gulp-compile-handlebars": "^0.6.1",
+    "gulp-compile-handlebars": "^0.6.0",
     "gulp-concat": "^2.6.0",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-method-override": "0.0.3",
     "express-session": "^1.10.2",
     "gulp": "^3.8.11",
-    "gulp-compile-handlebars": "^0.5.0",
+    "gulp-compile-handlebars": "^0.6.1",
     "gulp-concat": "^2.6.0",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.3.0",


### PR DESCRIPTION
Currently the version is 0.5.1. In a seperate project, compilation failed when using this version - upgrading fixed this is.

0.6.0 brings additional windows and partial support. Even though this may be a minor upgrade, it may be helpful for future projects using slate.

https://github.com/kaanon/gulp-compile-handlebars/releases